### PR TITLE
add proxy_url to enable ghteam-auth with http proxy

### DIFF
--- a/src/ghclient.rs
+++ b/src/ghclient.rs
@@ -19,7 +19,13 @@ impl GithubClient {
         if std::env::var("SSL_CERT_FILE").is_err() {
             std::env::set_var("SSL_CERT_FILE", &config.cert_path);
         }
-        GithubClient { client: reqwest::Client::new(),
+        GithubClient { client: match config.proxy_url {
+                           Some(ref proxy_url) => {
+                               let p = reqwest::Proxy::all(proxy_url).unwrap();
+                               reqwest::Client::builder().proxy(p).build().unwrap()
+                           }
+                           None => reqwest::Client::new(),
+                       },
                        conf: config.clone(), }
     }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -23,6 +23,7 @@ pub struct Config {
     pub cert_path: String,
     #[serde(default = "default_user_conf_path")]
     pub user_conf_path: String,
+    pub proxy_url: Option<String>,
 }
 
 fn default_endpoint() -> String { String::from("https://api.github.com") }


### PR DESCRIPTION
This pull request adds `proxy_url: Option<String>` to config, to support HTTP proxy.